### PR TITLE
Expose weapon damage attributes for mechs

### DIFF
--- a/docs/custom-mech-models.md
+++ b/docs/custom-mech-models.md
@@ -168,8 +168,8 @@ getAttribute(Attributes.MOVEMENT_SPEED).addTransientModifier(
     new AttributeModifier("dash_boost", 0.25, AttributeModifier.Operation.MULTIPLY_TOTAL));
 ```
 
-The extension also registers weapon-specific attributes so their values can be
-inspected and changed through the `/attribute` command:
+The extension also registers weapon-specific attributes and an energy gauge so
+their values can be inspected and changed through the `/attribute` command:
 
 | Attribute | Purpose |
 |-----------|---------|
@@ -177,6 +177,7 @@ inspected and changed through the `/attribute` command:
 | `pomkotsmechsextension:mech_machinegun_damage` | Damage dealt by gatling bullets |
 | `pomkotsmechsextension:mech_missile_damage` | Damage for missile explosions |
 | `pomkotsmechsextension:mech_saber_damage` | Melee damage for sabers and piles |
+| `pomkotsmechsextension:mech_energy` | Maximum capacity of the internal energy gauge |
 
 Like vanilla attributes these support the three modifier operations above, so
 addons can apply flat bonuses or multiplicative boosts.
@@ -189,7 +190,7 @@ Modifier operations:
 
 ## 9. Attribute reference
 
-**Mod stats** – `MECH_HEALTH`, `MECH_PILE_DAMAGE`, `MECH_GATLING_DAMAGE`, `MECH_GRENADE_DAMAGE`, `MECH_GRENADE_EXPLOSION`, `MECH_MISSILE_DAMAGE`, `MECH_MISSILE_EXPLOSION`, and the weapon constants in `CombatBalance` for base damage and projectile speed.  An internal energy gauge is consumed by boosts and weapons.
+**Mod stats** – `MECH_HEALTH`, `MECH_PILE_DAMAGE`, `MECH_GATLING_DAMAGE`, `MECH_GRENADE_DAMAGE`, `MECH_GRENADE_EXPLOSION`, `MECH_MISSILE_DAMAGE`, `MECH_MISSILE_EXPLOSION`, and the weapon constants in `CombatBalance` for base damage and projectile speed.  `MECH_ENERGY` controls the size of the internal gauge consumed by boosts and weapons.
 
 **Vanilla attributes** – `MAX_HEALTH`, `ATTACK_KNOCKBACK`, `KNOCKBACK_RESISTANCE` and any other `Attribute` supported by Minecraft can be attached to mechs for further tuning.
 

--- a/docs/custom-mech-models.md
+++ b/docs/custom-mech-models.md
@@ -168,6 +168,19 @@ getAttribute(Attributes.MOVEMENT_SPEED).addTransientModifier(
     new AttributeModifier("dash_boost", 0.25, AttributeModifier.Operation.MULTIPLY_TOTAL));
 ```
 
+The extension also registers weapon-specific attributes so their values can be
+inspected and changed through the `/attribute` command:
+
+| Attribute | Purpose |
+|-----------|---------|
+| `pomkotsmechsextension:mech_beam_damage` | Base damage for beam projectiles |
+| `pomkotsmechsextension:mech_machinegun_damage` | Damage dealt by gatling bullets |
+| `pomkotsmechsextension:mech_missile_damage` | Damage for missile explosions |
+| `pomkotsmechsextension:mech_saber_damage` | Melee damage for sabers and piles |
+
+Like vanilla attributes these support the three modifier operations above, so
+addons can apply flat bonuses or multiplicative boosts.
+
 Modifier operations:
 
 * **ADDITION** – flat bonus, e.g. `+5` health
@@ -179,3 +192,7 @@ Modifier operations:
 **Mod stats** – `MECH_HEALTH`, `MECH_PILE_DAMAGE`, `MECH_GATLING_DAMAGE`, `MECH_GRENADE_DAMAGE`, `MECH_GRENADE_EXPLOSION`, `MECH_MISSILE_DAMAGE`, `MECH_MISSILE_EXPLOSION`, and the weapon constants in `CombatBalance` for base damage and projectile speed.  An internal energy gauge is consumed by boosts and weapons.
 
 **Vanilla attributes** – `MAX_HEALTH`, `ATTACK_KNOCKBACK`, `KNOCKBACK_RESISTANCE` and any other `Attribute` supported by Minecraft can be attached to mechs for further tuning.
+
+Other useful vanilla stats include `MOVEMENT_SPEED`, `FLYING_SPEED`, `ARMOR`,
+`ARMOR_TOUGHNESS`, `ATTACK_DAMAGE`, `ATTACK_SPEED`, and `LUCK` which can be
+combined with modifiers to further customize mech behavior.

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/PomkotsMechsExtension.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/PomkotsMechsExtension.java
@@ -8,6 +8,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.PomkotsMechs;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.*;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.vehicle.*;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.items.*;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -148,7 +149,8 @@ public class PomkotsMechsExtension {
 //		AutoConfig.register(grcmcs.minecraft.mods.pomkotsmechs.config.PomkotsConfig.class, GsonConfigSerializer::new);
 //		CONFIG = AutoConfig.getConfigHolder(grcmcs.minecraft.mods.pomkotsmechs.config.PomkotsConfig.class).getConfig();
 
-		ENTITIES.register();
+                ModAttributes.init();
+                ENTITIES.register();
 
 		EntityAttributeRegistry.register(PMGZ01::get, Pmgz01Entity::createMobAttributes);
 		EntityAttributeRegistry.register(PMGZ02::get, Pmgz02Entity::createMobAttributes);

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/config/CombatBalance.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/config/CombatBalance.java
@@ -21,4 +21,6 @@ public class CombatBalance {
     public static final float BASE_SPEED_MACHINEGUN = 2.5F;
 
     public static final int BASE_DAMAGE_SABER = BASE_DAMAGE * 10;
+
+    public static final int BASE_ENERGY = 100;
 }

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01Entity.java
@@ -8,6 +8,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action
 import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.*;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -34,7 +35,11 @@ public class Pmac01Entity extends PmaBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmac01Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -87,7 +92,7 @@ public class Pmac01Entity extends PmaBaseEntity {
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            BulletLargeEntity be = new BulletLargeEntity(PomkotsMechsExtension.BULLETLARGE.get(), level, this, CombatBalance.BASE_DAMAGE_BEAM * 2 / 3);
+            BulletLargeEntity be = new BulletLargeEntity(PomkotsMechsExtension.BULLETLARGE.get(), level, this, (int)(getBeamDamage() * 2 / 3));
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -109,7 +114,7 @@ public class Pmac01Entity extends PmaBaseEntity {
 
     private void fireGatling(Level level) {
         if (!level.isClientSide()) {
-            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this, CombatBalance.BASE_DAMAGE_MACHINEGUN * 2 / 3);
+            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this, (int)(getMachineGunDamage() * 2 / 3));
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -146,7 +151,7 @@ public class Pmac01Entity extends PmaBaseEntity {
             for (int i = 0; i < 4; i++) {
                 var worldMuzzlPos = muzzlPos.add(1 * (i / 2 - 0.5),1 * (i % 2),0).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, CombatBalance.BASE_DAMAGE_MISSILE * 2 / 3);
+                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage() * 2 / 3);
 
                 be.setPos(offset.add(worldMuzzlPos));
 
@@ -168,7 +173,7 @@ public class Pmac01Entity extends PmaBaseEntity {
             var muzzlPos = new Vec3(1.3F, 18F/2, 2F/2);
             var worldMuzzlPos = muzzlPos.add(1 * (slot / 3),0,-2 - ((slot % 3) * 1)).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-            MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, CombatBalance.BASE_DAMAGE_MISSILE * 2 / 3);
+            MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage() * 2 / 3);
 
             be.setPos(offset.add(worldMuzzlPos));
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01Entity.java
@@ -39,7 +39,8 @@ public class Pmac01Entity extends PmaBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmac01Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01cEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01cEntity.java
@@ -9,6 +9,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BulletLargeEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MachineGunBulletEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -27,7 +28,11 @@ public class Pmac01cEntity extends Pmac01Entity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmac01cEntity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01cEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01cEntity.java
@@ -32,7 +32,8 @@ public class Pmac01cEntity extends Pmac01Entity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmac01cEntity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02Entity.java
@@ -36,7 +36,8 @@ public class Pmac02Entity extends PmaBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmac02Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02Entity.java
@@ -8,6 +8,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamLargeEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -31,7 +32,11 @@ public class Pmac02Entity extends PmaBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmac02Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -91,7 +96,7 @@ public class Pmac02Entity extends PmaBaseEntity {
         } else if (actionController.getAction(ACT_SABER).isOnFire()
                 || actionController.getAction(ACT_SABER2).isOnFire()
                 || actionController.getAction(ACT_SABER3).isOnFire()) {
-            this.fireSaber(level, CombatBalance.BASE_DAMAGE_SABER * 2 / 3);
+            this.fireSaber(level, getSaberDamage() * 2 / 3);
         } else if (actionController.getAction(ACT_BAZOOKA).isOnFire()) {
             this.fireBazooka(level);
         }
@@ -99,7 +104,7 @@ public class Pmac02Entity extends PmaBaseEntity {
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this, CombatBalance.BASE_DAMAGE_BEAM * 2 / 3);
+            BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this, (int)(getBeamDamage() * 2 / 3));
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -122,7 +127,7 @@ public class Pmac02Entity extends PmaBaseEntity {
     private void fireBazooka(Level level) {
         if (!level.isClientSide()) {
             for (int i = 0; i < 3; i+=2) {
-                BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this, CombatBalance.BASE_DAMAGE_BEAM * 2 / 3);
+                BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this, (int)(getBeamDamage() * 2 / 3));
 
                 // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
                 // ので、3tick前の座標をオフセットにする

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02cEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02cEntity.java
@@ -29,7 +29,8 @@ public class Pmac02cEntity extends Pmac02Entity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmac02cEntity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02cEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02cEntity.java
@@ -6,6 +6,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action
 import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -24,7 +25,11 @@ public class Pmac02cEntity extends Pmac02Entity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmac02cEntity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/PmgBaseEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/PmgBaseEntity.java
@@ -9,6 +9,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action
 import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.ActionController;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
@@ -312,8 +313,24 @@ public abstract class PmgBaseEntity extends PomkotsVehicleBase {
         return new float[]{(float)xRot, (float)yRot};
     }
 
+    protected float getBeamDamage() {
+        return (float) this.getAttributeValue(ModAttributes.MECH_BEAM_DAMAGE.get());
+    }
+
+    protected float getMissileDamage() {
+        return (float) this.getAttributeValue(ModAttributes.MECH_MISSILE_DAMAGE.get());
+    }
+
+    protected float getMachineGunDamage() {
+        return (float) this.getAttributeValue(ModAttributes.MECH_MACHINEGUN_DAMAGE.get());
+    }
+
+    protected float getSaberDamage() {
+        return (float) this.getAttributeValue(ModAttributes.MECH_SABER_DAMAGE.get());
+    }
+
     protected void fireSaber(Level level) {
-        this.fireSaber(level, CombatBalance.BASE_DAMAGE_SABER);
+        this.fireSaber(level, getSaberDamage());
     }
 
     protected void fireSaber(Level level, float damage) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/PmgBaseEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/PmgBaseEntity.java
@@ -35,15 +35,12 @@ import java.util.List;
 public abstract class PmgBaseEntity extends PomkotsVehicleBase {
     public static final float DEFAULT_SCALE = 1.0f;
 
+    protected int energy = CombatBalance.BASE_ENERGY;
+    private boolean energyInitialized = false;
+
     @Override
     protected String getMechName() {
         return "base";
-    }
-
-    @Override
-    protected boolean useEnergy(int dec) {
-        dec = dec * 2;
-        return super.useEnergy(dec);
     }
 
     @Override
@@ -62,6 +59,11 @@ public abstract class PmgBaseEntity extends PomkotsVehicleBase {
 
     @Override
     public void tick() {
+        if (!energyInitialized) {
+            energy = getMaxEnergy();
+            energyInitialized = true;
+        }
+
         super.tick();
 
         if (this.onGround()) {
@@ -77,6 +79,36 @@ public abstract class PmgBaseEntity extends PomkotsVehicleBase {
         }
         previousMode = this.isMainMode();
         previousOnground = this.onGround();
+    }
+
+    @Override
+    public int getEnergy() {
+        return energy;
+    }
+
+    protected int getMaxEnergy() {
+        return (int) this.getAttributeValue(ModAttributes.MECH_ENERGY.get());
+    }
+
+    @Override
+    protected void chargeEnergy() {
+        int max = getMaxEnergy();
+        if (energy > max) {
+            energy = max;
+        } else if (energy < max) {
+            energy = Math.min(max, energy + 2);
+        }
+    }
+
+    @Override
+    protected boolean useEnergy(int dec) {
+        dec = dec * 2;
+        if (energy - dec < 0) {
+            energy = 0;
+            return false;
+        }
+        energy -= dec;
+        return true;
     }
 
     protected void handleCollisionWithProjectiles() {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge01Entity.java
@@ -35,7 +35,8 @@ public class Pmge01Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmge01Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge01Entity.java
@@ -7,6 +7,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action
 import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.*;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -30,7 +31,11 @@ public class Pmge01Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.6);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.6)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmge01Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -76,7 +81,7 @@ public class Pmge01Entity extends PmgBaseEntity {
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this);
+            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this, (int)getMachineGunDamage());
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge02Entity.java
@@ -9,6 +9,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MachineGunBulletEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.ZakuBazookaEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -30,7 +31,11 @@ public class Pmge02Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.6);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.6)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmge02Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -146,7 +151,7 @@ public class Pmge02Entity extends PmgBaseEntity {
 
     private void fireGatling(Level level) {
         if (!level.isClientSide()) {
-            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this);
+            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this, (int)getMachineGunDamage());
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge02Entity.java
@@ -35,7 +35,8 @@ public class Pmge02Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmge02Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge03Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge03Entity.java
@@ -29,7 +29,8 @@ public class Pmge03Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmge03Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge03Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge03Entity.java
@@ -8,6 +8,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamLargeEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -24,7 +25,11 @@ public class Pmge03Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.75);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.75)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmge03Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -77,7 +82,7 @@ public class Pmge03Entity extends PmgBaseEntity {
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
             for (int i = 0; i < 2; i++) {
-                BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this);
+                BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this, (int)getBeamDamage());
 
                 // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
                 // ので、3tick前の座標をオフセットにする
@@ -101,7 +106,7 @@ public class Pmge03Entity extends PmgBaseEntity {
     private void fireBazooka(Level level) {
         if (!level.isClientSide()) {
             for (int i = 0; i < 3; i+=2) {
-                BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this);
+                BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this, (int)(getBeamDamage() * 2));
 
                 // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
                 // ので、3tick前の座標をオフセットにする
@@ -139,7 +144,7 @@ public class Pmge03Entity extends PmgBaseEntity {
             for (int i = 0; i < 6; i++) {
                 var worldMuzzlPos = muzzlPos.add(4.5 * (i / 3 - 0.5),1 * (i % 3),0).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null);
+                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage());
 
                 be.setPos(offset.add(worldMuzzlPos));
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge04Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge04Entity.java
@@ -10,6 +10,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamLargeEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.damagesource.DamageSource;
@@ -39,7 +40,11 @@ public class Pmge04Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.3)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmge04Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -91,7 +96,7 @@ public class Pmge04Entity extends PmgBaseEntity {
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this);
+            BeamEntity be = new BeamEntity(PomkotsMechsExtension.BEAM.get(), level, this, (int)getBeamDamage());
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -113,7 +118,7 @@ public class Pmge04Entity extends PmgBaseEntity {
 
     private void fireBazooka(Level level) {
         if (!level.isClientSide()) {
-            BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this);
+            BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this, (int)(getBeamDamage() * 2));
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -149,7 +154,7 @@ public class Pmge04Entity extends PmgBaseEntity {
             for (int i = 0; i < 6; i++) {
                 var worldMuzzlPos = muzzlPos.add(2 * (i / 3),2 * (i % 3),0).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null);
+                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage());
 
                 be.setPos(offset.add(worldMuzzlPos));
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge04Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmge04Entity.java
@@ -44,7 +44,8 @@ public class Pmge04Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmge04Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgx01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgx01Entity.java
@@ -32,7 +32,8 @@ public class Pmgx01Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmgx01Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgx01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgx01Entity.java
@@ -6,6 +6,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action
 import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -27,7 +28,11 @@ public class Pmgx01Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.7);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.7)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmgx01Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -97,11 +102,11 @@ public class Pmgx01Entity extends PmgBaseEntity {
     }
 
     private void fireChest(Level level) {
-        this.fireSaber(level, CombatBalance.BASE_DAMAGE_SABER * 1.5F, 100);
+            this.fireSaber(level, getSaberDamage() * 1.5F, 100);
     }
 
     private void fireTetsu(Level level) {
-        this.fireSaber(level, CombatBalance.BASE_DAMAGE_SABER * 1.2F, 100);
+            this.fireSaber(level, getSaberDamage() * 1.2F, 100);
     }
 
     private void fireMissile(Level level) {
@@ -117,7 +122,7 @@ public class Pmgx01Entity extends PmgBaseEntity {
             for (int i = 0; i < 6; i++) {
                 var worldMuzzlPos = muzzlPos.add(4.5 * (i / 3 - 0.5),1 * (i % 3),0).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, CombatBalance.BASE_DAMAGE_MISSILE /2);
+                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage() / 2);
 
                 be.setPos(offset.add(worldMuzzlPos));
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz01Entity.java
@@ -35,7 +35,8 @@ public class Pmgz01Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmgz01Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz01Entity.java
@@ -9,6 +9,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MachineGunBulletEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.ZakuBazookaEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -30,7 +31,11 @@ public class Pmgz01Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.5);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.5)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmgz01Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -81,7 +86,7 @@ public class Pmgz01Entity extends PmgBaseEntity {
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this);
+            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this, (int)getMachineGunDamage());
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -143,7 +148,7 @@ public class Pmgz01Entity extends PmgBaseEntity {
             for (int i = 0; i < 6; i++) {
                 var worldMuzzlPos = muzzlPos.add(2 * (i / 3),2 * (i % 3),0).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null);
+                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage());
 
                 be.setPos(offset.add(worldMuzzlPos));
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz02Entity.java
@@ -9,6 +9,7 @@ import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamLargeEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MachineGunBulletEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -32,7 +33,11 @@ public class Pmgz02Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.4);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.4)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmgz02Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -88,13 +93,13 @@ public class Pmgz02Entity extends PmgBaseEntity {
         } else if (actionController.getAction(ACT_SABER).isOnFire()
                 || actionController.getAction(ACT_SABER2).isOnFire()
                 || actionController.getAction(ACT_SABER3).isOnFire()) {
-            this.fireSaber(level, CombatBalance.BASE_DAMAGE_SABER * 1.5F);
+            this.fireSaber(level, getSaberDamage() * 1.5F);
         }
     }
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this);
+            MachineGunBulletEntity be = new MachineGunBulletEntity(PomkotsMechsExtension.MACHINEGUNBULLET.get(), level, this, (int)getMachineGunDamage());
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz02Entity.java
@@ -37,7 +37,8 @@ public class Pmgz02Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmgz02Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03Entity.java
@@ -7,8 +7,8 @@ import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action
 import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.BeamLargeEntity;
-import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MachineGunBulletEntity;
 import grcmcs.minecraft.mods.pomkotsmechs.extension.entity.projectile.MissileHorizontalEntity;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -32,7 +32,11 @@ public class Pmgz03Entity extends PmgBaseEntity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.75);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.75)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmgz03Entity(EntityType<? extends LivingEntity> entityType, Level world) {
@@ -102,7 +106,7 @@ public class Pmgz03Entity extends PmgBaseEntity {
 
     private void fireShoot(Level level) {
         if (!level.isClientSide()) {
-            BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this);
+            BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this, (int)(getBeamDamage() * 2));
 
             // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
             // ので、3tick前の座標をオフセットにする
@@ -125,7 +129,7 @@ public class Pmgz03Entity extends PmgBaseEntity {
     private void fireBazooka(Level level) {
         if (!level.isClientSide()) {
             for (int i = 0; i < 3; i+=2) {
-                BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this);
+                BeamLargeEntity be = new BeamLargeEntity(PomkotsMechsExtension.BEAMLARGE.get(), level, this, (int)(getBeamDamage() * 2));
 
                 // 原因不明なんだけど、getPosした時の座標と、レンダリングされてる座標で3tick分ぐらい乖離がある気配がする
                 // ので、3tick前の座標をオフセットにする
@@ -163,7 +167,7 @@ public class Pmgz03Entity extends PmgBaseEntity {
             for (int i = 0; i < 6; i++) {
                 var worldMuzzlPos = muzzlPos.add(2 * (i / 3),2 * (i % 3),0).yRot((float) Math.toRadians((-1.0) * this.getYRot()));
 
-                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null);
+                MissileHorizontalEntity be = new MissileHorizontalEntity(PomkotsMechsExtension.MISSILE.get(), level, this, null, getMissileDamage());
 
                 be.setPos(offset.add(worldMuzzlPos));
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03Entity.java
@@ -36,7 +36,8 @@ public class Pmgz03Entity extends PmgBaseEntity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmgz03Entity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03yEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03yEntity.java
@@ -22,7 +22,8 @@ public class Pmgz03yEntity extends Pmgz03Entity {
                 .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
                 .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
                 .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
-                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER)
+                .add(ModAttributes.MECH_ENERGY.get(), CombatBalance.BASE_ENERGY);
     }
 
     public Pmgz03yEntity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03yEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz03yEntity.java
@@ -1,6 +1,7 @@
 package grcmcs.minecraft.mods.pomkotsmechs.extension.entity.vehicle;
 
 import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.registry.ModAttributes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
@@ -17,7 +18,11 @@ public class Pmgz03yEntity extends Pmgz03Entity {
         return createLivingAttributes()
                 .add(Attributes.ATTACK_KNOCKBACK)
                 .add(Attributes.KNOCKBACK_RESISTANCE, 0.8)
-                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.75);
+                .add(Attributes.MAX_HEALTH, CombatBalance.BASE_HEALTH * 0.75)
+                .add(ModAttributes.MECH_BEAM_DAMAGE.get(), CombatBalance.BASE_DAMAGE_BEAM)
+                .add(ModAttributes.MECH_MACHINEGUN_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MACHINEGUN)
+                .add(ModAttributes.MECH_MISSILE_DAMAGE.get(), CombatBalance.BASE_DAMAGE_MISSILE)
+                .add(ModAttributes.MECH_SABER_DAMAGE.get(), CombatBalance.BASE_DAMAGE_SABER);
     }
 
     public Pmgz03yEntity(EntityType<? extends LivingEntity> entityType, Level world) {

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/registry/ModAttributes.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/registry/ModAttributes.java
@@ -28,6 +28,10 @@ public class ModAttributes {
             () -> new RangedAttribute("attribute.name." + PomkotsMechsExtension.MODID + ".mech_saber_damage",
                     CombatBalance.BASE_DAMAGE_SABER, 0.0D, 2048.0D).setSyncable(true));
 
+    public static final RegistrySupplier<Attribute> MECH_ENERGY = ATTRIBUTES.register("mech_energy",
+            () -> new RangedAttribute("attribute.name." + PomkotsMechsExtension.MODID + ".mech_energy",
+                    CombatBalance.BASE_ENERGY, 0.0D, 2048.0D).setSyncable(true));
+
     public static void init() {
         ATTRIBUTES.register();
     }

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/registry/ModAttributes.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/registry/ModAttributes.java
@@ -1,0 +1,34 @@
+package grcmcs.minecraft.mods.pomkotsmechs.extension.registry;
+
+import dev.architectury.registry.registries.DeferredRegister;
+import dev.architectury.registry.registries.RegistrySupplier;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.PomkotsMechsExtension;
+import grcmcs.minecraft.mods.pomkotsmechs.extension.config.CombatBalance;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+
+public class ModAttributes {
+    public static final DeferredRegister<Attribute> ATTRIBUTES =
+            DeferredRegister.create(PomkotsMechsExtension.MODID, Registries.ATTRIBUTE);
+
+    public static final RegistrySupplier<Attribute> MECH_BEAM_DAMAGE = ATTRIBUTES.register("mech_beam_damage",
+            () -> new RangedAttribute("attribute.name." + PomkotsMechsExtension.MODID + ".mech_beam_damage",
+                    CombatBalance.BASE_DAMAGE_BEAM, 0.0D, 2048.0D).setSyncable(true));
+
+    public static final RegistrySupplier<Attribute> MECH_MISSILE_DAMAGE = ATTRIBUTES.register("mech_missile_damage",
+            () -> new RangedAttribute("attribute.name." + PomkotsMechsExtension.MODID + ".mech_missile_damage",
+                    CombatBalance.BASE_DAMAGE_MISSILE, 0.0D, 2048.0D).setSyncable(true));
+
+    public static final RegistrySupplier<Attribute> MECH_MACHINEGUN_DAMAGE = ATTRIBUTES.register("mech_machinegun_damage",
+            () -> new RangedAttribute("attribute.name." + PomkotsMechsExtension.MODID + ".mech_machinegun_damage",
+                    CombatBalance.BASE_DAMAGE_MACHINEGUN, 0.0D, 2048.0D).setSyncable(true));
+
+    public static final RegistrySupplier<Attribute> MECH_SABER_DAMAGE = ATTRIBUTES.register("mech_saber_damage",
+            () -> new RangedAttribute("attribute.name." + PomkotsMechsExtension.MODID + ".mech_saber_damage",
+                    CombatBalance.BASE_DAMAGE_SABER, 0.0D, 2048.0D).setSyncable(true));
+
+    public static void init() {
+        ATTRIBUTES.register();
+    }
+}


### PR DESCRIPTION
## Summary
- register beam, missile, machinegun and saber damage attributes
- use these attributes when firing weapons
- document new attributes and additional vanilla stats

## Testing
- `./gradlew build` *(fails: Could not find geckolib-forge-1.20.1-4.4.9-deobf.jar)*
- `./gradlew test` *(fails: Could not find geckolib-forge-1.20.1-4.4.9-deobf.jar)*
- `./gradlew check` *(fails: Could not find geckolib-forge-1.20.1-4.4.9-deobf.jar)*

------
https://chatgpt.com/codex/tasks/task_e_688ebb695f08832796a60cfe5fcdcd75