### PR TITLE
Remove duplicate energy methods

### DIFF
--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac01Entity.java
@@ -264,5 +264,4 @@ public class Pmac01Entity extends PmaBaseEntity {
         }));
     }
 
-    @Override
 }

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmac02Entity.java
@@ -248,6 +248,5 @@ public class Pmac02Entity extends PmaBaseEntity {
         }));
     }
 
-    @Override
 }
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/PmgBaseEntity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/PmgBaseEntity.java
@@ -112,38 +112,6 @@ public abstract class PmgBaseEntity extends PomkotsVehicleBase {
         return true;
     }
 
-    @Override
-    public int getEnergy() {
-        return energy;
-    }
-
-    protected int getMaxEnergy() {
-        return (int) this.getAttributeValue(ModAttributes.MECH_ENERGY.get());
-    }
-
-    @Override
-    protected void chargeEnergy() {
-        int max = getMaxEnergy();
-        if (energy > max) {
-            energy = max;
-        } else if (energy < max) {
-            energy = Math.min(max, energy + 2);
-        }
-    }
-
-    @Override
-    protected boolean useEnergy(int dec) {
-        // innate modifier: base class doubles the requested energy cost
-        dec = Math.round(dec * CombatBalance.ENERGY_COST_MULTIPLIER);
-
-        if (energy - dec < 0) {
-            energy = 0;
-            return false;
-        }
-        energy -= dec;
-        return true;
-    }
-
     protected void handleCollisionWithProjectiles() {
         // ボスのAABB（現在の位置からの範囲）
         AABB bossBoundingBox = this.getBoundingBox();

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgx01Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgx01Entity.java
@@ -225,6 +225,5 @@ public class Pmgx01Entity extends PmgBaseEntity {
         }));
     }
 
-    @Override
 }
 

--- a/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz02Entity.java
+++ b/forge/src/main/java/grcmcs/minecraft/mods/pomkotsmechs/extension/entity/vehicle/Pmgz02Entity.java
@@ -230,6 +230,5 @@ public class Pmgz02Entity extends PmgBaseEntity {
         return Mth.abs((float)vel.x) > 0.3 || Mth.abs((float)vel.z) > 0.3 || Mth.abs((float)vel.y) > 0.3;
     }
 
-    @Override
 }
 


### PR DESCRIPTION
## Summary
- drop duplicated energy management overrides in PmgBaseEntity
- clean stray `@Override` annotations from several entity classes for successful compilation

## Testing
- `./gradlew :forge:compileJava`


------
https://chatgpt.com/codex/tasks/task_e_688effb20ee88327b14c34d56af3f61d