### PR TITLE
Register mixin configuration in mods.toml

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -54,3 +54,6 @@ mandatory = true
 versionRange = "[0.0.1-alpha.4,)"
 ordering = "AFTER"
 side = "CLIENT"
+
+[[mixins]]
+config = "pomkotsmechsextension.mixins.json"


### PR DESCRIPTION
## Summary
- register `pomkotsmechsextension.mixins.json` in Forge `mods.toml` so the mixins config is discovered at runtime

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_688f03eb7c90832784005d6ed32c8702