### PR TITLE
Replace Loom with ForgeGradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@ buildscript {
 
 plugins {
     id 'org.spongepowered.mixin' version '0.7.+' apply false
-    id 'dev.architectury.loom' version '1.6-SNAPSHOT' apply false
-    id 'architectury-plugin' version '3.4-SNAPSHOT' apply false
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'dev.architectury.loom'
-    id 'architectury-plugin'
+    id 'net.minecraftforge.gradle' version '6.0.+' 
     id 'com.github.johnrengelman.shadow'
     id 'maven-publish'
 }
@@ -9,16 +8,8 @@ base {
     archivesName = "${rootProject.archives_name}-${project.name}"
 }
 
-loom {
-    forge {
-        mixinConfig "pomkotsmechsextension.mixins.json"
-    }
-}
-
-architectury {
-    minecraft = rootProject.minecraft_version
-    platformSetupLoomIde()
-    forge()
+minecraft {
+    mappings channel: 'official', version: rootProject.minecraft_version
 }
 
 configurations {
@@ -46,19 +37,13 @@ repositories {
     }
 }
 
-
 dependencies {
-    minecraft "net.minecraft:minecraft:${rootProject.minecraft_version}"
-    mappings loom.officialMojangMappings()
-    forge "net.minecraftforge:forge:$rootProject.forge_version"
+    minecraft "net.minecraftforge:forge:${rootProject.forge_version}"
 
-    // Architectury API. This is optional, and you can comment it out if you don't need it.
-    modImplementation "dev.architectury:architectury-forge:$rootProject.architectury_api_version"
-    implementation("software.bernie.geckolib:geckolib-forge-${minecraft_version}:${geckolib_version}")
-    implementation("com.eliotlash.mclib:mclib:20")
-    implementation(name: 'pomkotsmechs-forge-0.0.1-alpha.4-dev-shadow', ext: 'jar')
-
-    modApi("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}")
+    implementation fg.deobf("software.bernie.geckolib:geckolib-forge-${rootProject.minecraft_version}:${rootProject.geckolib_version}")
+    implementation fg.deobf("com.eliotlash.mclib:mclib:20")
+    implementation files('libs/pomkotsmechs-forge-0.0.1-alpha.4-dev-shadow.jar')
+    implementation fg.deobf("me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_config_version}")
 }
 
 java {
@@ -92,11 +77,16 @@ processResources {
     }
 }
 
+// Configure the shaded jar and reobfuscation
 shadowJar {
     configurations = [project.configurations.shadowBundle]
-    archiveClassifier = 'dev-shadow'
+    archiveClassifier.set('')
+    finalizedBy 'reobfShadowJar'
 }
 
-remapJar {
-    input.set shadowJar.archiveFile
+reobf {
+    shadowJar {}
 }
+
+tasks.build.dependsOn 'reobfShadowJar'
+

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -1,1 +1,0 @@
-loom.platform = forge

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@ archives_name = pomkotsmechsextension
 minecraft_version = 1.20.1
 
 # Dependencies
-architectury_api_version = 9.2.14
 forge_version = 1.20.1-47.3.3
 # GeckoLib version used for animations
 geckolib_version=4.4.9

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
     repositories {
-        maven { url "https://maven.fabricmc.net/" }
-        maven { url "https://maven.architectury.dev/" }
         maven { url "https://files.minecraftforge.net/maven/" }
         maven { url 'https://repo.spongepowered.org/repository/maven-public/' }
         gradlePluginPortal()


### PR DESCRIPTION
## Summary
- remove Architectury/Loom plugins from root and Forge builds
- switch Forge module to ForgeGradle with official mappings and reobfShadowJar
- drop Loom-specific properties and repositories

## Testing
- `./gradlew build` *(fails: No locally installed toolchains match and toolchain download repositories have not been configured)*
- `./gradlew test` *(fails: Task :forge:compileJava FAILED)*
- `./gradlew check` *(fails: Task :forge:compileJava FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_688ff00218308327adcfa9d9f65e8442