### PR TITLE
Fix UTF-8 encoding

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -52,8 +52,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+// Ensure sources compile consistently across platforms with UTF-8 encoding
 tasks.withType(JavaCompile).configureEach {
-    it.options.release = 17
+    options.release = 17
+    options.encoding = 'UTF-8'
 }
 
 publishing {


### PR DESCRIPTION
## Summary
- ensure Java sources compile as UTF-8

## Testing
- `./gradlew build` *(fails: Could not find net.minecraftforge:forge:1.20.1-47.3.3_mapped_official_1.20.1)*

------
https://chatgpt.com/codex/tasks/task_e_688fff9246e88327be3bab4e2008d365