### PR TITLE
Add Architectury dependency

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -26,7 +26,11 @@ repositories {
         dirs 'libs'  // プロジェクト内のlibsフォルダを指定
     }
 
+    mavenCentral()
+    maven { url 'https://maven.minecraftforge.net/' }
+
     maven { url "https://maven.shedaniel.me/" }
+    maven { url "https://maven.architectury.dev/" }
     maven {
         name = 'GeckoLib'
         url 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/'
@@ -44,6 +48,7 @@ dependencies {
     implementation fg.deobf("com.eliotlash.mclib:mclib:20")
     implementation files('libs/pomkotsmechs-forge-0.0.1-alpha.4-dev-shadow.jar')
     implementation fg.deobf("me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_config_version}")
+    implementation fg.deobf("dev.architectury:architectury-forge:${rootProject.architectury_version}")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Done to increase the memory available to Gradle.
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
+org.gradle.java.home=/root/.local/share/mise/installs/java/17
 
 # Mod properties
 mod_version = 0.0.1-alpha.2
@@ -15,3 +16,4 @@ forge_version = 1.20.1-47.3.3
 # GeckoLib version used for animations
 geckolib_version=4.4.9
 cloth_config_version=11.1.118
+architectury_version=9.2.14


### PR DESCRIPTION
## Summary
- include Architectury repository and Forge artifact
- configure Java 17 home and Architectury version

## Testing
- `./gradlew build -Dnet.minecraftforge.gradle.check.certs=false` *(fails: Task ':forge:shadowJar' has implicit dependency issue)*
- `./gradlew test -Dnet.minecraftforge.gradle.check.certs=false`
- `./gradlew check -Dnet.minecraftforge.gradle.check.certs=false`


------
https://chatgpt.com/codex/tasks/task_e_689007c25e0c83278790c15403191b0b