### PR TITLE
fix: update base mod dependency identifiers

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     "java": ">=17",
     "architectury": ">=9.2.14",
     "geckolib": ">=4.4.9",
-    "pomkotsmechs": ">=0.0.1-alpha.4",
+    "pomkotsmechsextension": ">=0.0.1-alpha.4",
     "leawind_third_person": ">=2.1.0",
     "fabric-api": "*"
   },

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -49,7 +49,7 @@ ordering = "AFTER"
 side = "CLIENT"
 
 [[dependencies.pmegundamuniverse]]
-modId = "pomkotsmechs"
+modId = "pomkotsmechsextension"
 mandatory = true
 versionRange = "[0.0.1-alpha.4,)"
 ordering = "AFTER"


### PR DESCRIPTION
## Summary
- update Fabric mod descriptor to depend on `pomkotsmechsextension`
- point Forge dependency block at `pomkotsmechsextension`

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6894c4638ef48327a42a77a03b357eb3