### PR TITLE
Add Gundam mech combat actions and animations

### DIFF
--- a/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/GundamMechEntity.java
+++ b/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/GundamMechEntity.java
@@ -1,31 +1,81 @@
 package net.bluelotuscoding.pmegundamuniverse.entity;
 
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.entity.Entity;
+import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.PomkotsVehicleBase;
+import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.Action;
+import grcmcs.minecraft.mods.pomkotsmechs.entity.vehicle.equipment.action.ActionController;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
+import software.bernie.geckolib.core.animation.AnimatableManager;
+import software.bernie.geckolib.core.animation.AnimationController;
+import software.bernie.geckolib.core.animation.AnimationState;
+import software.bernie.geckolib.core.animation.RawAnimation;
+import software.bernie.geckolib.core.object.PlayState;
 
 /**
- * Base class for Gundam mechs added by the addon.
- * TODO: extend the core mod's PmgBaseEntity when available.
+ * Base class for Gundam mechs added by the addon. This now extends the
+ * Pomkots vehicle base so actions and GeckoLib animations can be used.
  */
-public class GundamMechEntity extends Entity {
-    public GundamMechEntity(EntityType<? extends Entity> type, Level level) {
+public class GundamMechEntity extends PomkotsVehicleBase {
+    protected static final int ACT_SHOOT = 7;
+    protected static final int ACT_SABER = 8;
+    protected static final int ACT_BAZOOKA = 9;
+    protected static final int ACT_GATLING = 10;
+
+    public GundamMechEntity(EntityType<? extends LivingEntity> type, Level level) {
         super(type, level);
     }
 
     @Override
-    protected void defineSynchedData() {
-        // TODO: sync Gundam data
+    protected String getMechName() {
+        // All sample animations use the my_mech namespace
+        return "my_mech";
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag tag) {
-        // TODO: read custom data
+    protected void registerActions() {
+        super.registerActions();
+        registerCombatActions();
+    }
+
+    /**
+     * Registers weapon actions for this mech. Each action contains
+     * a cooldown, charge duration and active fire window and is
+     * mapped to the limb that performs it.
+     */
+    protected void registerCombatActions() {
+        actionController.registerAction(ACT_SHOOT, new Action(20, 10, 10),
+            ActionController.ActionType.R_ARM_MAIN);
+        actionController.registerAction(ACT_SABER, new Action(60, 11, 9),
+            ActionController.ActionType.L_ARM_MAIN);
+        actionController.registerAction(ACT_BAZOOKA, new Action(60, 15, 15),
+            ActionController.ActionType.R_SHL_MAIN);
+        actionController.registerAction(ACT_GATLING, new Action(40, 10, 10),
+            ActionController.ActionType.L_SHL_MAIN);
     }
 
     @Override
-    protected void addAdditionalSaveData(CompoundTag tag) {
-        // TODO: write custom data
+    protected void addExtraAnimationController(AnimatableManager.ControllerRegistrar controllers) {
+        controllers.add(new AnimationController<>(this, "attack", 2, this::attackAnimation));
+    }
+
+    private <E extends GundamMechEntity> PlayState attackAnimation(AnimationState<E> event) {
+        if (actionController.getAction(ACT_SHOOT).isInAction()) {
+            return event.setAndContinue(RawAnimation.begin()
+                .thenPlay("animation." + getMechName() + ".shoot"));
+        }
+        if (actionController.getAction(ACT_SABER).isInAction()) {
+            return event.setAndContinue(RawAnimation.begin()
+                .thenPlay("animation." + getMechName() + ".saber"));
+        }
+        if (actionController.getAction(ACT_BAZOOKA).isInAction()) {
+            return event.setAndContinue(RawAnimation.begin()
+                .thenPlay("animation." + getMechName() + ".bazooka"));
+        }
+        if (actionController.getAction(ACT_GATLING).isInAction()) {
+            return event.setAndContinue(RawAnimation.begin()
+                .thenPlay("animation." + getMechName() + ".gatling1"));
+        }
+        return PlayState.STOP;
     }
 }

--- a/forge/src/main/resources/assets/pomkotsmechsextension/animations/my_mech.animation.json
+++ b/forge/src/main/resources/assets/pomkotsmechsextension/animations/my_mech.animation.json
@@ -1,0 +1,14 @@
+{
+  "animations": {
+    "shoot": {}, "shootUpperBody": {},
+    "shoot1": {}, "shoot2": {}, "shoot1_upper": {}, "shoot2_upper": {},
+    "shootL1": {}, "shootL2": {}, "shootL1_upper": {}, "shootL2_upper": {},
+    "saber": {}, "saberUpperBody": {},
+    "saber1": {}, "saber2": {}, "saber3": {},
+    "saber1_upper": {}, "saber2_upper": {}, "saber3_upper": {},
+    "bazooka": {}, "bazooka_upper": {},
+    "missile": {}, "missileUpperBody": {},
+    "gatling1": {}, "gatling2": {},
+    "vz": {}, "vz_upper": {}
+  }
+}


### PR DESCRIPTION
## Summary
- Extend `GundamMechEntity` from core vehicle base
- Register shoot, saber, bazooka and gatling actions with limb assignments
- Add animation controller to play action-specific clips and include sample animation definitions

## Testing
- `./gradlew build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68950c5313608327a26bd5c833532a2e