### PR TITLE
Add energy-based abilities to Gundam mechs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,7 @@ What went well:
 What went wrong:
 Improvements:
 ```
+
+## Recent Insights
+- Added placeholder `PomkotsVehicleBase` with an energy gauge to support mech ability tests.
+- Implemented `GundamMechEntity` ability hooks that consume energy and trigger simple effects.

--- a/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/GundamMechEntity.java
+++ b/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/GundamMechEntity.java
@@ -1,17 +1,89 @@
 package net.bluelotuscoding.pmegundamuniverse.entity;
 
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.entity.Entity;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 /**
  * Base class for Gundam mechs added by the addon.
  * TODO: extend the core mod's PmgBaseEntity when available.
  */
-public class GundamMechEntity extends Entity {
-    public GundamMechEntity(EntityType<? extends Entity> type, Level level) {
+public class GundamMechEntity extends PomkotsVehicleBase {
+    private static final float DASH_COST = 10.0F;
+    private static final float DASH_SIDE_COST = 8.0F;
+    private static final float JUMP_COST = 12.0F;
+    private static final float COCKPIT_COST = 2.0F;
+
+    private boolean cockpitOpen;
+
+    public GundamMechEntity(EntityType<? extends PomkotsVehicleBase> type, Level level) {
         super(type, level);
+    }
+
+    /**
+     * Forward dash ability.
+     */
+    public void dash() {
+        if (consumeEnergy(DASH_COST)) {
+            Vec3 dir = getLookAngle().scale(1.5F);
+            setDeltaMovement(getDeltaMovement().add(dir));
+            level().playSound(null, blockPosition(), SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1.0F, 1.0F);
+        }
+    }
+
+    /**
+     * Side dash ability.
+     *
+     * @param left true for left, false for right
+     */
+    public void dashSide(boolean left) {
+        if (consumeEnergy(DASH_SIDE_COST)) {
+            Vec3 side = getLookAngle().yRot(left ? (float) Math.PI / 2F : (float) -Math.PI / 2F).scale(1.2F);
+            setDeltaMovement(getDeltaMovement().add(side));
+            level().playSound(null, blockPosition(), SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 1.0F, 1.0F);
+        }
+    }
+
+    public void evasionLeft() {
+        dashSide(true);
+    }
+
+    public void evasionRight() {
+        dashSide(false);
+    }
+
+    /**
+     * Jump ability consuming energy.
+     */
+    public void jump() {
+        if (onGround() && consumeEnergy(JUMP_COST)) {
+            setDeltaMovement(getDeltaMovement().add(0.0D, 1.0D, 0.0D));
+            level().addParticle(ParticleTypes.CLOUD, getX(), getY(), getZ(), 0.0D, 0.0D, 0.0D);
+        }
+    }
+
+    /**
+     * Opens the cockpit if closed.
+     */
+    public void cockpitOpen() {
+        if (!cockpitOpen && consumeEnergy(COCKPIT_COST)) {
+            cockpitOpen = true;
+            level().playSound(null, blockPosition(), SoundEvents.IRON_TRAPDOOR_OPEN, SoundSource.PLAYERS, 1.0F, 1.0F);
+        }
+    }
+
+    /**
+     * Closes the cockpit if open.
+     */
+    public void cockpitClose() {
+        if (cockpitOpen && consumeEnergy(COCKPIT_COST)) {
+            cockpitOpen = false;
+            level().playSound(null, blockPosition(), SoundEvents.IRON_TRAPDOOR_CLOSE, SoundSource.PLAYERS, 1.0F, 1.0F);
+        }
     }
 
     @Override

--- a/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/PomkotsVehicleBase.java
+++ b/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/PomkotsVehicleBase.java
@@ -1,0 +1,55 @@
+package net.bluelotuscoding.pmegundamuniverse.entity;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+
+/**
+ * Simplified vehicle base providing an energy gauge.
+ * This placeholder is used until the core Pomkots Mechs API is available.
+ */
+public class PomkotsVehicleBase extends Entity {
+    private float energy = 100.0F;
+    private final float maxEnergy = 100.0F;
+
+    public PomkotsVehicleBase(EntityType<? extends Entity> type, Level level) {
+        super(type, level);
+    }
+
+    /**
+     * Attempts to consume energy from the gauge.
+     *
+     * @param amount energy to consume
+     * @return {@code true} if enough energy was available
+     */
+    public boolean consumeEnergy(float amount) {
+        if (energy >= amount) {
+            energy -= amount;
+            return true;
+        }
+        return false;
+    }
+
+    public float getEnergy() {
+        return energy;
+    }
+
+    public void setEnergy(float energy) {
+        this.energy = Math.min(energy, maxEnergy);
+    }
+
+    @Override
+    protected void defineSynchedData() {
+    }
+
+    @Override
+    protected void readAdditionalSaveData(CompoundTag tag) {
+        energy = tag.getFloat("Energy");
+    }
+
+    @Override
+    protected void addAdditionalSaveData(CompoundTag tag) {
+        tag.putFloat("Energy", energy);
+    }
+}

--- a/docs/reflections/extend-gundammechentity-abilities.md
+++ b/docs/reflections/extend-gundammechentity-abilities.md
@@ -1,0 +1,5 @@
+Goal: Implement ability methods for GundamMechEntity with energy consumption and effects.
+Outcome: Added dash, side dash, evasion, jump, and cockpit open/close with energy deductions and basic animations.
+What went well: Created placeholder PomkotsVehicleBase, implemented abilities, and ensured compilation hooks.
+What went wrong: Lack of core API required creation of simplified energy gauge placeholder.
+Improvements: Integrate real Pomkots Mechs API once available and expand effects to actual animations.


### PR DESCRIPTION
## Summary
- Add placeholder `PomkotsVehicleBase` with an energy gauge
- Extend `GundamMechEntity` with dash, side dash, evasion, jump, and cockpit open/close abilities
- Record development insights and reflection

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68950c53a0c88327bd5ce5f93e1a46a0