### PR TITLE
Add mech animation and effect hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,10 @@ When turning a substantial fork into a lean addon that depends on an upstream mo
 - After each task, note what went well and what could be improved. Update this guide with any new insights.
 - Continuously refine workflows so future tasks are executed more efficiently.
 - Maintain an internal log of lessons learned and share them through code comments or documentation.
-- 
+
+## Recent Insights
+- Prototype hooks for pilot accuracy-driven animations and mech effects were added. Integrate these with real statistics and rendering systems in future work.
+
 ## Fork Audit
 Track deviations from the upstream repository with `docs/fork_audit.csv`. Regenerate it after syncing with upstream using:
 ```

--- a/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/GundamMechEntity.java
+++ b/common/src/main/java/net/bluelotuscoding/pmegundamuniverse/entity/GundamMechEntity.java
@@ -10,6 +10,8 @@ import net.minecraft.world.level.Level;
  * TODO: extend the core mod's PmgBaseEntity when available.
  */
 public class GundamMechEntity extends Entity {
+    private float mechJumpSustain;
+
     public GundamMechEntity(EntityType<? extends Entity> type, Level level) {
         super(type, level);
     }
@@ -27,5 +29,60 @@ public class GundamMechEntity extends Entity {
     @Override
     protected void addAdditionalSaveData(CompoundTag tag) {
         // TODO: write custom data
+    }
+
+    /**
+     * Retrieves the pilot's accuracy rating.
+     * <p>
+     * Currently returns a placeholder value until pilot stats are implemented.
+     *
+     * @return pilot accuracy from 0-1
+     */
+    protected float getPilotAccuracy() {
+        return 1.0f; // TODO: calculate actual pilot accuracy
+    }
+
+    /**
+     * Dash skid animation scaled by pilot accuracy.
+     */
+    protected void playDashSkidAnimation() {
+        float intensity = getPilotAccuracy();
+        // TODO: trigger dash skid animation with intensity
+    }
+
+    /**
+     * Hover lean animation scaled by pilot accuracy.
+     */
+    protected void playHoverLeanAnimation() {
+        float intensity = getPilotAccuracy();
+        // TODO: trigger hover lean animation with intensity
+    }
+
+    /**
+     * Cockpit reaction animation scaled by pilot accuracy.
+     */
+    protected void playCockpitReactionAnimation() {
+        float intensity = getPilotAccuracy();
+        // TODO: trigger cockpit reaction animation with intensity
+    }
+
+    /**
+     * Prototype overheat particle or sound effects.
+     */
+    protected void spawnOverheatEffects() {
+        float intensity = getPilotAccuracy();
+        // TODO: spawn overheat effects based on intensity
+    }
+
+    /**
+     * Prototype vertical thrust effects scaled by mech jump sustain.
+     */
+    protected void spawnVerticalThrustEffects() {
+        float sustain = getMechJumpSustain();
+        // TODO: spawn vertical thrust effects based on sustain
+    }
+
+    protected float getMechJumpSustain() {
+        return mechJumpSustain; // TODO: read from mech attributes
     }
 }

--- a/docs/reflections/2024-06-09-animation-effect-hooks.md
+++ b/docs/reflections/2024-06-09-animation-effect-hooks.md
@@ -1,0 +1,5 @@
+Goal: Introduce animation and effect prototypes and update documentation.
+Outcome: Added placeholder methods for mech animations and effects and documented hooks.
+What went well: Code compiled and checks passed; documentation updated cleanly.
+What went wrong: No runtime validation of animations or effects due to placeholder nature.
+Improvements: Implement actual animations, particles, and sound handling linked to pilot stats.

--- a/docs/unimplemented-suggestions.md
+++ b/docs/unimplemented-suggestions.md
@@ -3,9 +3,9 @@
 This document tracks enhancement ideas that remain to be implemented in the Pomkots Mechs extension.
 
 ## Animation and Visual Effects
-- Dash skid, hover lean, and cockpit reaction animations that vary with pilot accuracy.
-- Vertical-thrust effects that scale with `mech_jump_sustain`, such as hover jets or exhaust plumes.
-- Overheat, malfunction, or vent sequences showing smoke, sparks, steam, or warning alarms when energy or jump sustain is pushed too high.
+- Dash skid, hover lean, and cockpit reaction animations that vary with pilot accuracy. Prototype hooks: `GundamMechEntity#playDashSkidAnimation`, `playHoverLeanAnimation`, and `playCockpitReactionAnimation`.
+- Vertical-thrust effects that scale with `mech_jump_sustain`, such as hover jets or exhaust plumes. Prototype hook: `GundamMechEntity#spawnVerticalThrustEffects`.
+- Overheat, malfunction, or vent sequences showing smoke, sparks, steam, or warning alarms when energy or jump sustain is pushed too high. Prototype hook: `GundamMechEntity#spawnOverheatEffects`.
 - Startup/shutdown, low-health warning, and other situational animations to enhance immersion.
 
 ## Combat and Movement Mechanics


### PR DESCRIPTION
## Summary
- add pilot accuracy–scaled animation placeholders for dash skid, hover lean, and cockpit reactions
- stub overheat and vertical thrust effects that scale with `mech_jump_sustain`
- document newly added hooks in the suggestions guide and record task insights

## Testing
- `./gradlew build`
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68950c558dcc83278e78e218580953bb